### PR TITLE
Run PHPStan against FOSSBilling source

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -2,16 +2,16 @@ name: Build and Test
 
 on:
   push:
-    branches: main
+    branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
 
 jobs:
   composer:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.0 ]
+        php: [8.2]
 
     name: PHP ${{ matrix.php }} - Build and Archive
     steps:
@@ -50,12 +50,12 @@ jobs:
 
   phpstan:
     runs-on: ubuntu-latest
-    needs: [ composer ]
+    needs: [composer]
     strategy:
       matrix:
-        php: [ 8.0 ]
+        php: [8.2]
 
-    name: PHPStan
+    name: PHPStan - FOSSBilling Preview
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -64,6 +64,23 @@ jobs:
 
       - name: Extract build archive
         run: tar -xvf /tmp/builds/build.tar ./
+
+      - name: Checkout FOSSBilling Source Code
+        uses: actions/checkout@v2
+        with:
+          repository: "FOSSBilling/FOSSBilling"
+          path: "FOSSBilling"
+
+      # We manually run composer commands because of this issue: https://github.com/php-actions/composer/issues/100
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer
+
+      - name: Install Composer Dependencies
+        run: composer install --no-progress --no-dev --no-interaction
+        working-directory: FOSSBilling
 
       - name: Run PHPStan
         uses: php-actions/phpstan@v3

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -112,7 +112,7 @@ jobs:
           args: --working-dir=FOSSBilling/src
 
       - name: Install Composer Dependencies (>=0.5.0)
-        if: ${{ hashFiles('FOSSBilling/src/composer.json') }}
+        if: ${{ hashFiles('FOSSBilling/composer.json') }}
         uses: php-actions/composer@v6
         with:
           args: --working-dir=FOSSBilling/

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -88,3 +88,52 @@ jobs:
           php_version: ${{ matrix.php }}
           configuration: phpstan.neon
           memory_limit: 512M
+
+  phpstan-release:
+    runs-on: ubuntu-latest
+    needs: [composer]
+    strategy:
+      matrix:
+        php: [8.2]
+
+    name: PHPStan - FOSSBilling Release
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-archive-php${{ matrix.php }}
+          path: /tmp/builds
+
+      - name: Extract build archive
+        run: tar -xvf /tmp/builds/build.tar ./
+
+      - name: Get the Latest FOSSBilling Release Tag
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: "FOSSBilling/FOSSBilling"
+          releases-only: true
+          id: get_id
+
+      - name: Checkout FOSSBilling The Release tag
+        uses: actions/checkout@v3
+        with:
+          repository: "FOSSBilling/FOSSBilling"
+          path: "FOSSBilling"
+          ref: ${{ steps.get_id.outputs.tag }}
+
+      # We manually run composer commands because of this issue: https://github.com/php-actions/composer/issues/100
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer
+
+      - name: Install Composer Dependencies
+        run: composer install --no-progress --no-dev --no-interaction
+        working-directory: FOSSBilling
+
+      - name: Run PHPStan
+        uses: php-actions/phpstan@v3
+        with:
+          php_version: ${{ matrix.php }}
+          configuration: phpstan.neon
+          memory_limit: 512M

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -119,12 +119,12 @@ jobs:
           tools: composer
 
       - name: Install Composer Dependencies (<=0.4.x)
-        if: ${{ hashFiles('/FOSSBilling/src/composer.json') }}
+        if: ${{ hashFiles('FOSSBilling/src/composer.json') }}
         run: composer install --no-progress --no-dev --no-interaction
         working-directory: FOSSBilling/src
 
       - name: Install Composer Dependencies (>=0.5.0)
-        if: ${{ hashFiles('/FOSSBilling/composer.json') }}
+        if: ${{ hashFiles('FOSSBilling/composer.json') }}
         run: composer install --no-progress --no-dev --no-interaction
         working-directory: FOSSBilling/
 

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -9,11 +9,8 @@ on:
 jobs:
   composer:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php: [8.2]
 
-    name: PHP ${{ matrix.php }} - Build and Archive
+    name: PHP (Latest) - Build and Archive
     steps:
       - uses: actions/checkout@v3
 
@@ -35,7 +32,7 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true'
         uses: php-actions/composer@v6
         with:
-          php_version: ${{ matrix.php }}
+          php_version: latest
 
       - name: Create Build Archive for Tests
         run: |
@@ -44,22 +41,19 @@ jobs:
       - name: Upload Build Archive for Tests
         uses: actions/upload-artifact@v3
         with:
-          name: build-archive-php${{ matrix.php }}
+          name: build-archive-php
           path: /tmp/builds
           retention-days: 1
 
   phpstan:
     runs-on: ubuntu-latest
     needs: [composer]
-    strategy:
-      matrix:
-        php: [8.2]
 
     name: PHPStan - FOSSBilling Preview
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: build-archive-php${{ matrix.php }}
+          name: build-archive-php
           path: /tmp/builds
 
       - name: Extract build archive
@@ -75,7 +69,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: latest
           tools: composer
 
       - name: Install Composer Dependencies
@@ -85,22 +79,19 @@ jobs:
       - name: Run PHPStan
         uses: php-actions/phpstan@v3
         with:
-          php_version: ${{ matrix.php }}
+          php_version: latest
           configuration: phpstan.neon
           memory_limit: 512M
 
   phpstan-release:
     runs-on: ubuntu-latest
     needs: [composer]
-    strategy:
-      matrix:
-        php: [8.2]
 
     name: PHPStan - FOSSBilling Release
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: build-archive-php${{ matrix.php }}
+          name: build-archive-php
           path: /tmp/builds
 
       - name: Extract build archive
@@ -111,7 +102,7 @@ jobs:
         with:
           repository: "FOSSBilling/FOSSBilling"
           releases-only: true
-          id: get_id
+        id: get_id
 
       - name: Checkout FOSSBilling The Release tag
         uses: actions/checkout@v3
@@ -124,7 +115,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: latest
           tools: composer
 
       - name: Install Composer Dependencies
@@ -134,6 +125,6 @@ jobs:
       - name: Run PHPStan
         uses: php-actions/phpstan@v3
         with:
-          php_version: ${{ matrix.php }}
+          php_version: latest
           configuration: phpstan.neon
           memory_limit: 512M

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -118,9 +118,15 @@ jobs:
           php-version: latest
           tools: composer
 
-      - name: Install Composer Dependencies
+      - name: Install Composer Dependencies (<=0.4.x)
+        if: ${{ hashFiles('/FOSSBilling/src/composer.json') }}
         run: composer install --no-progress --no-dev --no-interaction
-        working-directory: FOSSBilling
+        working-directory: FOSSBilling/src
+
+      - name: Install Composer Dependencies (>=0.5.0)
+        if: ${{ hashFiles('/FOSSBilling/composer.json') }}
+        run: composer install --no-progress --no-dev --no-interaction
+        working-directory: FOSSBilling/
 
       - name: Run PHPStan
         uses: php-actions/phpstan@v3

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Install Composer Dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         uses: php-actions/composer@v6
-        with:
-          php_version: latest
 
       - name: Create Build Archive for Tests
         run: |
@@ -98,7 +96,7 @@ jobs:
           releases-only: true
         id: get_id
 
-      - name: Checkout FOSSBilling The Release tag
+      - name: Checkout The Release tag
         uses: actions/checkout@v3
         with:
           repository: "FOSSBilling/FOSSBilling"

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -65,16 +65,10 @@ jobs:
           repository: "FOSSBilling/FOSSBilling"
           path: "FOSSBilling"
 
-      # We manually run composer commands because of this issue: https://github.com/php-actions/composer/issues/100
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: latest
-          tools: composer
-
       - name: Install Composer Dependencies
-        run: composer install --no-progress --no-dev --no-interaction
-        working-directory: FOSSBilling
+        uses: php-actions/composer@v6
+        with:
+          args: --working-dir=FOSSBilling
 
       - name: Run PHPStan
         uses: php-actions/phpstan@v3
@@ -111,22 +105,17 @@ jobs:
           path: "FOSSBilling"
           ref: ${{ steps.get_id.outputs.tag }}
 
-      # We manually run composer commands because of this issue: https://github.com/php-actions/composer/issues/100
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: latest
-          tools: composer
-
       - name: Install Composer Dependencies (<=0.4.x)
         if: ${{ hashFiles('FOSSBilling/src/composer.json') }}
-        run: composer install --no-progress --no-dev --no-interaction
-        working-directory: FOSSBilling/src
+        uses: php-actions/composer@v6
+        with:
+          args: --working-dir=FOSSBilling/src
 
       - name: Install Composer Dependencies (>=0.5.0)
-        if: ${{ hashFiles('FOSSBilling/composer.json') }}
-        run: composer install --no-progress --no-dev --no-interaction
-        working-directory: FOSSBilling/
+        if: ${{ hashFiles('FOSSBilling/src/composer.json') }}
+        uses: php-actions/composer@v6
+        with:
+          args: --working-dir=FOSSBilling/
 
       - name: Run PHPStan
         uses: php-actions/phpstan@v3

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: tar -xvf /tmp/builds/build.tar ./
 
       - name: Checkout FOSSBilling Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: "FOSSBilling/FOSSBilling"
           path: "FOSSBilling"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,9 +2,9 @@ name: Create a downloadable preview build
 
 on:
   push:
-    branches: main
+    branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,7 +1,8 @@
 name: Spellcheck
 on:
   pull_request:
-  push:
+  push: 
+    branches: [main]
 
 permissions:
   contents: read

--- a/cspell.json
+++ b/cspell.json
@@ -11,7 +11,8 @@
         "transid",
         "serie",
         "opencollective",
-        "shivammathur"
+        "shivammathur",
+        "oprypin"
     ],
     "ignorePaths": [
         "phpstan.neon"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,5 @@ parameters:
 		analyse:
 		- src/vendor
 		- FOSSBilling
+	ignoreErrors:
+		- '#^Function __trans not found\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,10 +1,9 @@
-includes:
-	- phpstan-baseline.neon
-
 parameters:
 	level: 1
 	paths:
 		- src
+		- FOSSBilling
 	excludePaths:
 		analyse:
 		- src/vendor
+		- FOSSBilling


### PR DESCRIPTION
This PR reworks the CI workflow to run PHPStan against the module and both the dev version of FOSSBilling and the latest release. This makes it easier to quickly check at least a base level compatibility for both the current and upcoming releases.
The "preview" check is failing as expected, as the code for this module is incompatible with our current dev branch (and as such, FOSSBilling version 0.5.0 once it's released).

The workflow uses the latest version of PHP, as FOSSBilling should always be supporting that. This means we shouldn't need to update the workflow when we change the supported versions for FOSSBilling.
If all seems well, this can ideally become a template workflow for module developers to check low-level compatibility with their module & get PHPStan feedback,

I also made a few minor fixes to the other workflows.