### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/FOSSBilling/Mollie/security/code-scanning/4](https://github.com/FOSSBilling/Mollie/security/code-scanning/4)

In general, the fix is to define an explicit `permissions` block for the workflow or for each job so that `GITHUB_TOKEN` has only the scopes required. Because all three jobs (`composer`, `phpstan`, `phpstan-release`) are read-only with respect to the repository, the least-privilege configuration is `contents: read`. No step in the provided snippet needs write access to contents, issues, or pull requests.

The single best way to fix this without changing existing functionality is to add a top-level `permissions:` block right under the workflow `name:` (or under the `on:` block) in `.github/workflows/php-ci.yml`, setting `contents: read`. This will apply to all jobs in the workflow and avoids duplication. No other scopes (such as `pull-requests` or `issues`) appear necessary for the given steps. No imports or external definitions are needed; it is a pure YAML configuration change within the shown file.

Specifically, in `.github/workflows/php-ci.yml`, after line 1 (`name: Build and Test`) insert:

```yaml
permissions:
  contents: read
```

and leave the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
