### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}


### PR DESCRIPTION
Potential fix for [https://github.com/FOSSBilling/Mollie/security/code-scanning/1](https://github.com/FOSSBilling/Mollie/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block either at the top level of the workflow (to apply to all jobs) or within the specific job, granting only the minimal scopes required. For this workflow, the job only checks out code, runs PHP/composer commands, and uploads an artifact; none of these require write access to repository contents or other resources via the `GITHUB_TOKEN`. Therefore, we can safely set `permissions: contents: read` either on the workflow or on the `build` job.

The single best, minimally invasive change is to add a top-level `permissions` block after the `on:` section. This will constrain the `GITHUB_TOKEN` for all jobs in this workflow (currently just `build`) without changing functionality. `actions/checkout` and `actions/upload-artifact` work fine with `contents: read`, and no other scopes are needed. Concretely, in `.github/workflows/preview.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–7) and the `jobs:` block (line 9). No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
